### PR TITLE
temporarily disable secure cookies to troubleshoot broken prod,

### DIFF
--- a/config/sessionOptions.js
+++ b/config/sessionOptions.js
@@ -3,7 +3,7 @@
  */
 const session = require('express-session')
 const MemcachedStore = require('connect-memcached')(session)
-const isProd = require('./isProd')
+// const isProd = require('./isProd')
 
 const sessionOptions = {
   key: 'tsid',
@@ -15,7 +15,8 @@ const sessionOptions = {
     maxAge: 14*24*60*60*1000,
     credentials: true,
     sameSite: 'strict',
-    secure: isProd
+    // commented out to try and figure out why cookies broke in prod
+    // secure: isProd
   },
   store: new MemcachedStore({
     // default port for memcached. it is the same in prod and dev.


### PR DESCRIPTION
no cookies are being set. The set-cookie header is missing entirely. The only thing I changed in this area was setting cookies.secure to true. This undoes that to see if it is the problem. If it is, it may be because it is proxied by nginx in prod.