### PR TITLE
Re-enable secure cookies in prod after nginx config fix

### DIFF
--- a/config/sessionOptions.js
+++ b/config/sessionOptions.js
@@ -3,7 +3,7 @@
  */
 const session = require('express-session')
 const MemcachedStore = require('connect-memcached')(session)
-// const isProd = require('./isProd')
+const isProd = require('./isProd')
 
 const sessionOptions = {
   key: 'tsid',
@@ -15,8 +15,7 @@ const sessionOptions = {
     maxAge: 14*24*60*60*1000,
     credentials: true,
     sameSite: 'strict',
-    // commented out to try and figure out why cookies broke in prod
-    // secure: isProd
+    secure: isProd
   },
   store: new MemcachedStore({
     // default port for memcached. it is the same in prod and dev.


### PR DESCRIPTION
This is detailed in issue #11 . Hopefully prod will not break this time and we'll be able to close that issue.